### PR TITLE
board: otter: ottercast-S3: workaround for busybox bug, not starting lo

### DIFF
--- a/buildroot/board/otter/ottercast-S3/post_build.sh
+++ b/buildroot/board/otter/ottercast-S3/post_build.sh
@@ -31,3 +31,4 @@ ln -fs /tmp/daemon.conf "$TARGET_DIR"/etc/pulse/daemon.conf
 
 mkdir -p "$TARGET_DIR"/root/.config/pulse
 mkdir -p "$TARGET_DIR"/var/lib/pulse
+mkdir -p "$TARGET_DIR"/var/lib/systemd/timesync

--- a/buildroot/board/otter/ottercast-S3/skeleton/etc/fstab
+++ b/buildroot/board/otter/ottercast-S3/skeleton/etc/fstab
@@ -1,3 +1,4 @@
 /dev/root / auto ro 0 1
 tmpfs  /var/lib/pulse  tmpfs  auto,noatime,size=1m,uid=1002,gid=1002,mode=0700  0  0
 tmpfs  /root/.config/pulse  tmpfs  auto,noatime,size=1m,uid=0,gid=0,mode=0700  0  0
+tmpfs  /var/lib/systemd/timesync  tmpfs  auto,noatime,size=5m,mode=0755,uid=1004,gid=1005  0  0

--- a/buildroot/board/otter/ottercast-S3/skeleton/etc/network/interfaces
+++ b/buildroot/board/otter/ottercast-S3/skeleton/etc/network/interfaces
@@ -1,4 +1,5 @@
 auto lo
+allow-hotplug lo
 iface lo inet loopback
 
 auto wlan0

--- a/buildroot/board/otter/ottercast-S3/skeleton/etc/network/interfaces
+++ b/buildroot/board/otter/ottercast-S3/skeleton/etc/network/interfaces
@@ -1,5 +1,4 @@
 auto lo
-allow-hotplug lo
 iface lo inet loopback
 
 auto wlan0

--- a/buildroot/board/otter/ottercast-S3/skeleton/etc/systemd/system/network.service
+++ b/buildroot/board/otter/ottercast-S3/skeleton/etc/systemd/system/network.service
@@ -7,11 +7,9 @@ Before=network.target
 Type=oneshot
 RemainAfterExit=yes
 
-# This file exists upstream, but contains a flush for the 
-# lo-Interface. This causes lo not to have an IP address.
+# This flush causes lo not to have an IP address.
 # https://bugs.busybox.net/show_bug.cgi?id=11001
-# 
-# This flush was removed here.
+#ExecStart=/sbin/ip addr flush dev lo
 
 ExecStart=/sbin/ifup -a
 ExecStop=/sbin/ifdown -a

--- a/buildroot/board/otter/ottercast-S3/skeleton/etc/systemd/system/network.service
+++ b/buildroot/board/otter/ottercast-S3/skeleton/etc/systemd/system/network.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Network Connectivity
+Wants=network.target
+Before=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# This file exists upstream, but contains a flush for the 
+# lo-Interface. This causes lo not to have an IP address.
+# https://bugs.busybox.net/show_bug.cgi?id=11001
+# 
+# This flush was removed here.
+
+ExecStart=/sbin/ifup -a
+ExecStop=/sbin/ifdown -a
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This commit adds a manual configuration for the lo (loopback) interface
in /etc/network/interface, which contains a IPv4 and IPv6 address.
It also contains a new systemd-service which is a workaround needed
because of busybox bug #11001.
https://bugs.busybox.net/show_bug.cgi?id=11001