### PR TITLE
package: ottercast_frontend: bump version to 0.3.2

### DIFF
--- a/buildroot/package/ottercast_frontend/build.mk
+++ b/buildroot/package/ottercast_frontend/build.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OTTERCAST_FRONTEND_VERSION = 0.3.1
+OTTERCAST_FRONTEND_VERSION = 0.3.2
 OTTERCAST_FRONTEND_LICENSE = MIT
 OTTERCAST_FRONTEND_LICENSE_FILES = LICENSE
 OTTERCAST_FRONTEND_SITE = $(call github,Ottercast,frontend,v$(OTTERCAST_FRONTEND_VERSION))


### PR DESCRIPTION
Changelog:
 - fix crash when reported track length less than 1 second
 - ensure monotonic clock is used to derive LVGL ticks